### PR TITLE
Fix broken libpng url

### DIFF
--- a/config/hooks/build-uqm-dependencies.chroot
+++ b/config/hooks/build-uqm-dependencies.chroot
@@ -22,7 +22,7 @@ export LIBICONV_URL="ftp://ftp.wayne.edu/pub/gnu/libiconv/libiconv-1.14.tar.gz"
 # envvar LIBPNG_URL
 #
 # Specifies the URL of the libpng source tarball you want to use.
-export LIBPNG_URL="ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.14.tar.xz"
+export LIBPNG_URL="ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng16/libpng-1.6.0.tar.xz"
 
 # envvar ZLIB_URL
 #


### PR DESCRIPTION
Fixes an url that has changed. In future, these static urls should be replaced automatically using some kind of clever system
